### PR TITLE
add Ethernet frame

### DIFF
--- a/src/datalink/ethernet/ethertype.rs
+++ b/src/datalink/ethernet/ethertype.rs
@@ -1,0 +1,163 @@
+use core::convert::TryFrom;
+
+#[derive(Debug, PartialEq)]
+pub enum EtherType {
+    Ipv4,
+    Ipv6,
+    Arp,
+    Unknown,
+}
+
+impl EtherType {
+    #[allow(dead_code)]
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        if let Ok(ethertype) = EtherType::try_from(bytes) {
+            ethertype
+        } else {
+            EtherType::Unknown
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn to_bytes(&self) -> [u8; 2] {
+        match self {
+            EtherType::Ipv4 => [0x08, 0x00],
+            EtherType::Ipv6 => [0x86, 0xDD],
+            EtherType::Arp => [0x08, 0x06],
+            EtherType::Unknown => [0x00, 0x00],
+        }
+    }
+}
+
+impl TryFrom<[u8; 2]> for EtherType {
+    type Error = ();
+
+    fn try_from(bytes: [u8; 2]) -> Result<Self, Self::Error> {
+        match (bytes[0], bytes[1]) {
+            (0x08, 0x00) => Ok(EtherType::Ipv4),
+            (0x86, 0xDD) => Ok(EtherType::Ipv6),
+            (0x08, 0x06) => Ok(EtherType::Arp),
+            _ => Ok(EtherType::Unknown),
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for EtherType {
+    type Error = ();
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        if bytes.len() != 2 {
+            return Err(());
+        }
+        let bytes_arr: [u8; 2] = [bytes[0], bytes[1]];
+        EtherType::try_from(bytes_arr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_bytes_ipv4() {
+        let bytes = [0x08, 0x00];
+        let expect = EtherType::Ipv4;
+        let actual = EtherType::from_bytes(&bytes);
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn test_from_bytes_ipv6() {
+        let bytes = [0x86, 0xDD];
+        let expect = EtherType::Ipv6;
+        let actual = EtherType::from_bytes(&bytes);
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn test_from_bytes_arp() {
+        let bytes = [0x08, 0x06];
+        let expect = EtherType::Arp;
+        let actual = EtherType::from_bytes(&bytes);
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn test_from_bytes_unknown() {
+        let bytes = [0x00, 0x00];
+        let expect = EtherType::Unknown;
+        let actual = EtherType::from_bytes(&bytes);
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn test_try_from_ipv4() {
+        let bytes = [0x08, 0x00];
+        let expect = EtherType::Ipv4;
+        let actual = EtherType::try_from(bytes).unwrap();
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn test_try_from_ipv6() {
+        let bytes = [0x86, 0xDD];
+        let expect = EtherType::Ipv6;
+        let actual = EtherType::try_from(bytes).unwrap();
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn test_try_from_arp() {
+        let bytes = [0x08, 0x06];
+        let expect = EtherType::Arp;
+        let actual = EtherType::try_from(bytes).unwrap();
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn test_try_from_unknown() {
+        let bytes = [0x00, 0x00];
+        let expect = EtherType::Unknown;
+        let actual = EtherType::try_from(bytes).unwrap();
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn test_try_from_invalid() {
+        let bytes: &[u8] = &[0x00, 0x00, 0x00];
+        let actual = EtherType::try_from(bytes);
+        assert!(actual.is_err());
+    }
+
+    #[test]
+    fn test_to_bytes_ipv4() {
+        let ethertype = EtherType::Ipv4;
+        let expect = [0x08, 0x00];
+        let actual = ethertype.to_bytes();
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn test_to_bytes_ipv6() {
+        let ethertype = EtherType::Ipv6;
+        let expect = [0x86, 0xDD];
+        let actual = ethertype.to_bytes();
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn test_to_bytes_arp() {
+        let ethertype = EtherType::Arp;
+        let expect = [0x08, 0x06];
+        let actual = ethertype.to_bytes();
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn test_to_bytes_unknown() {
+        let ethertype = EtherType::Unknown;
+        let expect = [0x00, 0x00];
+        let actual = ethertype.to_bytes();
+        assert_eq!(expect, actual);
+    }
+}

--- a/src/datalink/ethernet/header.rs
+++ b/src/datalink/ethernet/header.rs
@@ -1,0 +1,41 @@
+#[derive(Debug, PartialEq)]
+pub struct EthernetHeader {
+    pub destination_mac_address: [u8; 6],
+    pub source_mac_address: [u8; 6],
+    pub ethertype: [u8; 2],
+}
+
+impl EthernetHeader {
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        EthernetHeader {
+            destination_mac_address: bytes[0..6].try_into().expect("slice with incorrect length"),
+            source_mac_address: bytes[6..12]
+                .try_into()
+                .expect("slice with incorrect length"),
+            ethertype: bytes[12..14]
+                .try_into()
+                .expect("slice with incorrect length"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ethernet_header_from_bytes() {
+        let bytes: &[u8] = &[
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // Destination MAC
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Source MAC
+            0x08, 0x00, // EtherType (IPv4)
+        ];
+        let actual = EthernetHeader::from_bytes(bytes);
+        let expect = EthernetHeader {
+            destination_mac_address: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+            source_mac_address: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            ethertype: [0x08, 0x00],
+        };
+        assert_eq!(actual, expect);
+    }
+}

--- a/src/datalink/ethernet/mod.rs
+++ b/src/datalink/ethernet/mod.rs
@@ -1,0 +1,1 @@
+pub mod ethertype;

--- a/src/datalink/ethernet/mod.rs
+++ b/src/datalink/ethernet/mod.rs
@@ -1,1 +1,53 @@
 pub mod ethertype;
+pub mod header;
+
+use header::EthernetHeader;
+
+impl<'a> EthernetFrame<'a> {
+    #[allow(dead_code)]
+    pub fn from_bytes(bytes: &'a [u8]) -> Self {
+        let header = EthernetHeader::from_bytes(&bytes[0..14]);
+        let payload = &bytes[14..];
+        EthernetFrame { header, payload }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct EthernetFrame<'a> {
+    pub header: EthernetHeader,
+    pub payload: &'a [u8],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use header::EthernetHeader;
+
+    #[test]
+    fn test_ethernet_frame_from_bytes() {
+        let bytes: &[u8] = &[
+            // Ethernet Header
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // Destination MAC
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Source MAC
+            0x08, 0x00, // EtherType (IPv4)
+            // Payload
+            0x45, 0x00, 0x00, 0x3c, 0x1c, 0x46, 0x40, 0x00, 0x40, 0x06, 0x00, 0x00, 0xac, 0x10,
+            0x0a, 0x01, 0xac, 0x10, 0x0a, 0x02,
+        ];
+
+        let ethernet_frame = EthernetFrame::from_bytes(bytes);
+
+        let expect_header = EthernetHeader {
+            destination_mac_address: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+            source_mac_address: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            ethertype: [0x08, 0x00],
+        };
+        let expect_payload: &[u8] = &[
+            0x45, 0x00, 0x00, 0x3c, 0x1c, 0x46, 0x40, 0x00, 0x40, 0x06, 0x00, 0x00, 0xac, 0x10,
+            0x0a, 0x01, 0xac, 0x10, 0x0a, 0x02,
+        ];
+
+        assert_eq!(ethernet_frame.header, expect_header);
+        assert_eq!(ethernet_frame.payload, expect_payload);
+    }
+}

--- a/src/datalink/mod.rs
+++ b/src/datalink/mod.rs
@@ -1,0 +1,1 @@
+pub mod ethernet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+mod datalink;
+
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }


### PR DESCRIPTION
This pull request introduces a new implementation for handling Ethernet frames in a `no_std` Rust environment. It includes the addition of an `EtherType` enum, an `EthernetHeader` struct, and an `EthernetFrame` struct, along with their associated methods and unit tests. The changes are modular and well-tested, laying the groundwork for Ethernet frame parsing and manipulation.

### Ethernet Frame Parsing and Handling:

* Added an `EtherType` enum in `src/datalink/ethernet/ethertype.rs` with variants for IPv4, IPv6, ARP, and Unknown, along with methods for converting to and from byte arrays. Includes comprehensive unit tests for all methods.
* Introduced an `EthernetHeader` struct in `src/datalink/ethernet/header.rs` to represent Ethernet frame headers, with a `from_bytes` method for parsing headers from byte slices. Includes a unit test for validation.
* Added an `EthernetFrame` struct in `src/datalink/ethernet/mod.rs` to encapsulate an Ethernet frame, including its header and payload. Implemented a `from_bytes` method for constructing frames from raw bytes. Includes a unit test for end-to-end frame parsing.

### Codebase Organization:

* Modularized the Ethernet-related code by introducing a `src/datalink/ethernet` module and integrating it into the `datalink` module.
* Enabled `no_std` support by adding `#![no_std]` to `src/lib.rs`, making the library suitable for embedded environments.