### PR TITLE
add PacketBuilder and ethernet method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,40 @@
 #![no_std]
 
-mod datalink;
+pub mod datalink;
+
+use datalink::ethernet::EthernetFrame;
+use datalink::ethernet::header::EthernetHeader;
+
+pub struct PacketBuilder;
+
+impl Default for PacketBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PacketBuilder {
+    pub fn new() -> Self {
+        PacketBuilder
+    }
+
+    pub fn ethernet<'a>(
+        &self,
+        destination: [u8; 6],
+        source: [u8; 6],
+        ethertype: [u8; 2],
+        payload: &'a [u8],
+    ) -> EthernetFrame<'a> {
+        EthernetFrame {
+            header: EthernetHeader {
+                destination_mac_address: destination,
+                source_mac_address: source,
+                ethertype,
+            },
+            payload,
+        }
+    }
+}
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
@@ -9,10 +43,26 @@ pub fn add(left: u64, right: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datalink::ethernet::EthernetFrame;
+    use datalink::ethernet::header::EthernetHeader;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn test_packet_builder_ethernet() {
+        let builder = PacketBuilder::new();
+        let expect = EthernetFrame {
+            header: EthernetHeader {
+                destination_mac_address: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+                source_mac_address: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+                ethertype: [0x08, 0x00],
+            },
+            payload: &[0x45, 0x00],
+        };
+        let actual = builder.ethernet(
+            [0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+            [0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0x08, 0x00],
+            &[0x45, 0x00],
+        );
+        assert_eq!(expect, actual);
     }
 }


### PR DESCRIPTION
This pull request introduces a new `PacketBuilder` struct to the `src/lib.rs` file, enabling the creation of Ethernet frames. The changes include making the `datalink` module public, implementing the `PacketBuilder` struct with methods for constructing Ethernet frames, and adding a corresponding unit test. Below is a breakdown of the most important changes:

### New functionality for Ethernet frame creation:
* Made the `datalink` module public to expose its components for use in the `PacketBuilder` implementation.
* Added a `PacketBuilder` struct with a `new` method and an `ethernet` method. The `ethernet` method constructs an `EthernetFrame` using provided destination/source MAC addresses, ethertype, and payload. 

### Unit testing:
* Replaced the existing `it_works` test with a new `test_packet_builder_ethernet` test. The new test verifies the correctness of the `PacketBuilder::ethernet` method by comparing the generated Ethernet frame with an expected frame. (`[src/lib.rsR46-R66](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R46-R66)`)