### PR TITLE
change impl for MacAddress

### DIFF
--- a/src/address/mac_address.rs
+++ b/src/address/mac_address.rs
@@ -1,4 +1,84 @@
+const MULTICAST_BIT: u8 = 0x01;
+
 #[derive(Debug, PartialEq)]
-pub struct MacAddress {
-    pub octets: [u8; 6],
+pub struct MacAddress(pub u8, pub u8, pub u8, pub u8, pub u8, pub u8);
+
+impl MacAddress {
+    pub fn new(o1: u8, o2: u8, o3: u8, o4: u8, o5: u8, o6: u8) -> MacAddress {
+        MacAddress(o1, o2, o3, o4, o5, o6)
+    }
+
+    pub fn broadcast() -> MacAddress {
+        MacAddress(0xff, 0xff, 0xff, 0xff, 0xff, 0xff)
+    }
+
+    pub fn octets(&self) -> [u8; 6] {
+        [self.0, self.1, self.2, self.3, self.4, self.5]
+    }
+
+    pub fn is_broadcast(&self) -> bool {
+        self == &Self::broadcast()
+    }
+
+    pub fn is_multicast(&self) -> bool {
+        (self.0 & MULTICAST_BIT) == MULTICAST_BIT
+    }
+
+    pub fn is_unicast(&self) -> bool {
+        !self.is_multicast()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let expect = MacAddress(1, 2, 3, 4, 5, 6);
+        let actual = MacAddress::new(1, 2, 3, 4, 5, 6);
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn test_broadcast() {
+        let expect = MacAddress(0xff, 0xff, 0xff, 0xff, 0xff, 0xff);
+        let actual = MacAddress::broadcast();
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn test_octets() {
+        let mac = MacAddress::new(1, 2, 3, 4, 5, 6);
+        let expect = [1, 2, 3, 4, 5, 6];
+        let actual = mac.octets();
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn test_is_broadcast() {
+        let mac = MacAddress::broadcast();
+        assert!(mac.is_broadcast());
+
+        let mac = MacAddress::new(1, 2, 3, 4, 5, 6);
+        assert!(!mac.is_broadcast());
+    }
+
+    #[test]
+    fn test_is_multicast() {
+        let mac = MacAddress::new(0x01, 0x02, 0x03, 0x04, 0x05, 0x06);
+        assert!(mac.is_multicast());
+
+        let mac = MacAddress::new(0x00, 0x02, 0x03, 0x04, 0x05, 0x06);
+        assert!(!mac.is_multicast());
+    }
+
+    #[test]
+    fn test_is_unicast() {
+        let mac = MacAddress::new(0x02, 0x02, 0x03, 0x04, 0x05, 0x06);
+        assert!(mac.is_unicast());
+
+        let mac = MacAddress::new(0x01, 0x02, 0x03, 0x04, 0x05, 0x06);
+        assert!(!mac.is_unicast());
+    }
 }

--- a/src/datalink/ethernet/header.rs
+++ b/src/datalink/ethernet/header.rs
@@ -10,14 +10,12 @@ pub struct EthernetHeader {
 impl EthernetHeader {
     pub fn from_bytes(bytes: &[u8]) -> Self {
         EthernetHeader {
-            destination_mac_address: MacAddress {
-                octets: bytes[0..6].try_into().expect("slice with incorrect length"),
-            },
-            source_mac_address: MacAddress {
-                octets: bytes[6..12]
-                    .try_into()
-                    .expect("slice with incorrect length"),
-            },
+            destination_mac_address: MacAddress::new(
+                bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5],
+            ),
+            source_mac_address: MacAddress::new(
+                bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], bytes[11],
+            ),
             ethertype: bytes[12..14]
                 .try_into()
                 .expect("slice with incorrect length"),
@@ -39,12 +37,8 @@ mod tests {
         ];
         let actual = EthernetHeader::from_bytes(bytes);
         let expect = EthernetHeader {
-            destination_mac_address: MacAddress {
-                octets: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
-            },
-            source_mac_address: MacAddress {
-                octets: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
-            },
+            destination_mac_address: MacAddress(0xff, 0xff, 0xff, 0xff, 0xff, 0xff),
+            source_mac_address: MacAddress(0x00, 0x00, 0x00, 0x00, 0x00, 0x00),
             ethertype: [0x08, 0x00],
         };
         assert_eq!(actual, expect);

--- a/src/datalink/ethernet/mod.rs
+++ b/src/datalink/ethernet/mod.rs
@@ -39,12 +39,8 @@ mod tests {
         let ethernet_frame = EthernetFrame::from_bytes(bytes);
 
         let expect_header = EthernetHeader {
-            destination_mac_address: MacAddress {
-                octets: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
-            },
-            source_mac_address: MacAddress {
-                octets: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
-            },
+            destination_mac_address: MacAddress(0xff, 0xff, 0xff, 0xff, 0xff, 0xff),
+            source_mac_address: MacAddress(0x00, 0x00, 0x00, 0x00, 0x00, 0x00),
             ethertype: [0x08, 0x00],
         };
         let expect_payload: &[u8] = &[

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,23 +53,15 @@ mod tests {
         let builder = PacketBuilder::new();
         let expect = EthernetFrame {
             header: EthernetHeader {
-                destination_mac_address: MacAddress {
-                    octets: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
-                },
-                source_mac_address: MacAddress {
-                    octets: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
-                },
+                destination_mac_address: MacAddress(0xff, 0xff, 0xff, 0xff, 0xff, 0xff),
+                source_mac_address: MacAddress(0x00, 0x00, 0x00, 0x00, 0x00, 0x00),
                 ethertype: [0x08, 0x00],
             },
             payload: &[0x45, 0x00],
         };
         let actual = builder.ethernet(
-            MacAddress {
-                octets: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
-            },
-            MacAddress {
-                octets: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
-            },
+            MacAddress(0xff, 0xff, 0xff, 0xff, 0xff, 0xff),
+            MacAddress(0x00, 0x00, 0x00, 0x00, 0x00, 0x00),
             [0x08, 0x00],
             &[0x45, 0x00],
         );


### PR DESCRIPTION
This pull request refactors the `MacAddress` struct in `src/address/mac_address.rs` to simplify its design and adds utility methods for common operations. It also updates related code in other modules to align with the new `MacAddress` structure. The most important changes include replacing the `MacAddress` struct's `octets` field with a tuple representation, adding utility methods, and updating tests and dependent code.

### Refactoring of `MacAddress`:

* [`src/address/mac_address.rs`](diffhunk://#diff-b1b46f7482c040dd8ca4cef03b4463d5e47a6cda15784bf950fee35f6f082d5eR1-R83): Refactored `MacAddress` to use a tuple representation instead of a struct with an `octets` field. Added utility methods such as `new`, `broadcast`, `octets`, `is_broadcast`, `is_multicast`, and `is_unicast`. Introduced comprehensive unit tests for the new methods.

### Updates to dependent code:

* [`src/datalink/ethernet/header.rs`](diffhunk://#diff-d0a3eb14048e694f60f6608e0134c97a6dc238638c06888b0bfcdc87faf84d9bL13-R18): Updated the `EthernetHeader` struct to use the new `MacAddress` tuple representation. Replaced the construction of `MacAddress` instances with the new `MacAddress::new` method. [[1]](diffhunk://#diff-d0a3eb14048e694f60f6608e0134c97a6dc238638c06888b0bfcdc87faf84d9bL13-R18) [[2]](diffhunk://#diff-d0a3eb14048e694f60f6608e0134c97a6dc238638c06888b0bfcdc87faf84d9bL42-R41)
* [`src/datalink/ethernet/mod.rs`](diffhunk://#diff-345ad91e782cbbc52ab4e50377b1896c9d61f9adc98ed99807f2e5a7d934ed46L42-R43): Modified tests to use the updated `MacAddress` tuple representation.
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L56-R64): Updated tests to reflect the new `MacAddress` structure and methods.